### PR TITLE
Fix config get_all that didn't filter env and cli args

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,30 +23,27 @@ const create_adapter = (path, default_entries) => {
 };
 
 module.exports = (default_configs, settings_path, envs = {}, cli_args = {}) => {
+    const default_keys = Object.keys(default_configs);
+    const filter = obj => JSON.parse(JSON.stringify(obj, default_keys));
     const config_file_path = _path.join(settings_path, FILENAME);
     const db = create_adapter(config_file_path);
     const current_config =  db.get_all();
     const config = Object.assign({}, default_configs, current_config);
     const cooked_config = Object.keys(config)
         .reduce((new_config, key) => {
-            const is_known_config = Object.keys(default_configs).includes(key);
-            if (is_known_config) {
-                Object.defineProperty(new_config, key, {
-                    get: () => cli_args[key] || envs[key] || db.get(key),
-                    set: new_value => {
-                        this[key] = new_value;
-                    },
-                    enumerable: true,
-                    configurable: true
-                });
-            } else {
-                delete config[key];
-            }
+            Object.defineProperty(new_config, key, {
+                get: () => cli_args[key] || envs[key] || db.get(key),
+                set: new_value => {
+                    this[key] = new_value;
+                },
+                enumerable: true,
+                configurable: true
+            });
             return new_config;
         }, {
-            get_all: () => Object.assign({}, db.get_all(), envs, cli_args),
+            get_all: () => filter(Object.assign({}, db.get_all(), envs, cli_args)),
             del: key => db.del(key)
         });
-    db.defaults(config);
+    db.defaults(filter(config));
     return cooked_config;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1226,9 +1226,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "logic-query-parser": {
-      "version": "git+https://github.com/AnyFetch/logic-query-parser.git#382fd5cd479b62f9c2cff4e847e732862be664b1"
-    },
     "lokijs": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.5.tgz",
@@ -1508,7 +1505,7 @@
       }
     },
     "open_bilrost_server": {
-      "version": "git+https://github.com/fl4re/open_bilrost_server.git#4290328b6da9fe39dcb2747a4bc7969cebd2e05b",
+      "version": "git+https://github.com/fl4re/open_bilrost_server.git#4399ed122d815a5daacfb61de0a8b5390716e81e",
       "dev": true,
       "requires": {
         "aws-sdk": "2.285.1",
@@ -1914,6 +1911,11 @@
       "version": "git+https://github.com/fl4re/search_parser.git#b722628d08066de2885124341eba936f13bff811",
       "requires": {
         "logic-query-parser": "git+https://github.com/AnyFetch/logic-query-parser.git#382fd5cd479b62f9c2cff4e847e732862be664b1"
+      },
+      "dependencies": {
+        "logic-query-parser": {
+          "version": "git+https://github.com/AnyFetch/logic-query-parser.git#382fd5cd479b62f9c2cff4e847e732862be664b1"
+        }
       }
     },
     "secure-keys": {

--- a/test/config.js
+++ b/test/config.js
@@ -50,6 +50,7 @@ describe('Authentication', function () {
         client.get('/config', function (err, req, res, obj) {
             assert.ifError(err);
             assert.equal(200, res.statusCode);
+            assert.equal(Object.keys(obj).length, 2);
             assert.deepEqual(obj, sample);
             done();
         });


### PR DESCRIPTION
`bilrost get-configs` used to return configs + envs + cli args. Now return configs only.

eg. 
```
sinopia>bilrost get-configs
BILROST_SERVER: http://localhost:3000
PORT:           9224
CACHE_PATH:     C:\Users\maxim\AppData\Roaming\Bilrost\Cache
PROTOCOL:       https
```