### PR TITLE
Deprecate '~/Library/Bilrost/Settings' folder, replaced with '~/Library/Bilrost/Config'

### DIFF
--- a/assetmanager/favorite.js
+++ b/assetmanager/favorite.js
@@ -12,19 +12,19 @@ const errors = require('../lib/errors')('favorite');
 
 const ConfProvider = require('nconf').Provider;
 const nconf = new ConfProvider();
-const settingsPath =/^win/.test(process.platform)?
-    Path.join(process.env.APPDATA,'/Bilrost/Settings/workspaces.json'):
-    Path.join(os.homedir(), '/Library/Bilrost/Settings/workspaces.json');
+const configPath =/^win/.test(process.platform)?
+    Path.join(process.env.APPDATA,'/Bilrost/Config/workspaces.json'):
+    Path.join(os.homedir(), '/Library/Bilrost/Config/workspaces.json');
 
 //init "itsWorkspaces" nconf instance by creating the file if doesn't exist
 try {
-    fs.statSync(settingsPath);
+    fs.statSync(configPath);
 } catch (err) {
     if (err.code === 'ENOENT') {
-        fs.outputJsonSync(settingsPath, { favorite:[] });
+        fs.outputJsonSync(configPath, { favorite:[] });
     }
 }
-nconf.file(settingsPath);
+nconf.file(configPath);
 
 const list = () => {
     const all = nconf.get("favorite");

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,7 +9,7 @@ Node proxy is using nconf as a key/value local store. For some use cases, we nee
 
 ### Which files?
 
-- Settings/workspaces.json 
+- Config/workspaces.json 
 
 This is used by the [content browser api]() for storing the workspace favorite list. Its JSON structure is like this:
 ```
@@ -22,7 +22,7 @@ This is used by the [content browser api]() for storing the workspace favorite l
 }
 ```
 
-- Settings/.session
+- Config/.session
 
 This stores session information to contact bilrost back end server.
 ```

--- a/proxy.js
+++ b/proxy.js
@@ -22,18 +22,9 @@ const INTERNAL_FOLDER_PATH = is_win ?
     path.join(process.env.APPDATA, 'Bilrost') :
     path.join(os.homedir(), 'Library/Bilrost');
 const CACHE_PATH = path.join(INTERNAL_FOLDER_PATH, 'Cache');
-const SETTINGS_PATH = path.join(INTERNAL_FOLDER_PATH, 'Settings');
 const CONFIG_PATH = path.join(INTERNAL_FOLDER_PATH, 'Config');
 
 // TODO deprecate folder creations
-
-try {
-    fs.statSync(SETTINGS_PATH);
-} catch (err){
-    if(err.code === 'ENOENT'){
-        fs.mkdirsSync(SETTINGS_PATH);
-    }
-}
 
 try {
     fs.statSync(CONFIG_PATH);
@@ -80,7 +71,7 @@ server.use((req, res, next) => {
 // CONTEXT
 //
 
-const bilrost_client = require('./lib/bilrost-client')(config.BILROST_SERVER, SETTINGS_PATH);
+const bilrost_client = require('./lib/bilrost-client')(config.BILROST_SERVER, CONFIG_PATH);
 const cache = require('./lib/cache')(config.CACHE_PATH);
 const amazon_client = require('./lib/amazon-client')(bilrost_client);
 


### PR DESCRIPTION
`workspaces.json` and `.session.json` are moved from `Settings` to `Config` folder. `Settings` directory is removed. This is relative to `~/Library/Bilrost/Cache` and `%APP_DATA%/Bilrost/Cache`.