### PR TITLE
Enforce downloading goes well by checking sha after completion

### DIFF
--- a/lib/amazon-s3.js
+++ b/lib/amazon-s3.js
@@ -31,8 +31,7 @@ const build_hash = path => new Promise((resolve, reject) => {
     hash.on('finish', () => {
         const read_hash = hash.read();
         resolve({
-            hash: read_hash,
-            data
+            hash: read_hash
         });
     });
     fd_hash.on('error', reject);
@@ -119,12 +118,16 @@ module.exports = (amazon_client, cache, config) => {
                     req.end();
                 })))
             .then(() => build_hash(cache.get_path(key, true)))
-            .then(output => {
-                if (output.hash === key) {
-                    return Promise.all([
-                        promisify(fs.rename)(cache.get_path(key, true), cache.get_path(key)),
-                        promisify(fs.writeFile)(location_path, output.data)
-                    ]);
+            .then(({ hash }) => {
+                if (hash === key) {
+                    return promisify(fs.rename)(cache.get_path(key, true), cache.get_path(key))
+                        .then(() => promisify(fs.copy)(cache.get_path(key), location_path))
+                        .then(() => build_hash(location_path))
+                        .then(({ hash }) => {
+                            if (hash !== key) {
+                                throw Error('Hash after copy from cache is invalid!');
+                            }
+                        });
                 } else {
                     return promisify(fs.unlink)(cache.get_path(key, true))
                         .then(() => {


### PR DESCRIPTION
Before we would download/write a resource within a workspace by fetching its content in-memory, collected with AWS S3 request. This doesn't make sense since we were writing the data within the cache at the same time. Now the download process happens like this:

1/ Stream finishes and data is collected
2/ Write data to a file stored in cache directory. Its name is a concatenation of its hash and '.tmp' extension
3/ Calculate hash of the cached file and ensure it is equal to its name without extension 
4/ Remove 'tmp' extension by renaming the cached filename
5/ Copy cached file to final workspace
6/ Check if workspace resource hash remains the same