### PR TITLE
Rename cache methods

### DIFF
--- a/lib/amazon-s3.js
+++ b/lib/amazon-s3.js
@@ -104,7 +104,7 @@ module.exports = (amazon_client, cache, config) => {
             .then(req => fs.ensureDir(cache.get_path())
                 .then(() => new Promise((resolve, reject) => {
                     console.log('Download', location_path, ' resource...');
-                    const write_stream = fs.createWriteStream(cache.get_path(key, true));
+                    const write_stream = fs.createWriteStream(cache.get_tmp_path(key));
                     req.on('result', (err, res) => {
                         if (err) {
                             reject(err);
@@ -117,10 +117,10 @@ module.exports = (amazon_client, cache, config) => {
                     });
                     req.end();
                 })))
-            .then(() => build_hash(cache.get_path(key, true)))
+            .then(() => build_hash(cache.get_tmp_path(key)))
             .then(({ hash }) => {
                 if (hash === key) {
-                    return promisify(fs.rename)(cache.get_path(key, true), cache.get_path(key))
+                    return promisify(fs.rename)(cache.get_tmp_path(key), cache.get_path(key))
                         .then(() => promisify(fs.copy)(cache.get_path(key), location_path))
                         .then(() => build_hash(location_path))
                         .then(({ hash }) => {
@@ -129,7 +129,7 @@ module.exports = (amazon_client, cache, config) => {
                             }
                         });
                 } else {
-                    return promisify(fs.unlink)(cache.get_path(key, true))
+                    return promisify(fs.unlink)(cache.get_tmp_path(key))
                         .then(() => {
                             throw "Pulled resource is corrupted";
                         });

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -8,18 +8,22 @@ const fs = require('fs-extra');
 const path = require('path');
 const promisify = require('../util/promisify');
 
-module.exports = cache_dir_path => ({
-    get_path: (key, is_temp) => path.join(cache_dir_path, (key ? key : '') + (is_temp ? '.tmp' : '')),
-    write: (key, file_path) => {
-        const cache_path = path.join(cache_dir_path, key);
-        return promisify(fs.copy)(file_path, cache_path);
-    },
-    exist: key => promisify(fs.access)(path.join(cache_dir_path, key))
-        .catch(err => {
-            throw "This cache entry doesn't exist";
-        }),
-    read: (key, target_path) => {
-        const cache_path = path.join(cache_dir_path, key);
-        return promisify(fs.copy)(cache_path, target_path);
-    }
-});
+module.exports = cache_dir_path => {
+    const cache = {
+        get_path: key => path.join(cache_dir_path, (key ? key : '')),
+        get_tmp_path: key => `${cache.get_path(key)}.tmp`,
+        write: (key, file_path) => {
+            const cache_path = path.join(cache_dir_path, key);
+            return promisify(fs.copy)(file_path, cache_path);
+        },
+        exist: key => promisify(fs.access)(path.join(cache_dir_path, key))
+            .catch(err => {
+                throw "This cache entry doesn't exist";
+            }),
+        read: (key, target_path) => {
+            const cache_path = path.join(cache_dir_path, key);
+            return promisify(fs.copy)(cache_path, target_path);
+        }
+    };
+    return cache;
+};

--- a/test/am/unit/repo_manager/s3.js
+++ b/test/am/unit/repo_manager/s3.js
@@ -36,6 +36,7 @@ const sha256 = content => crypto.createHash('sha256').update(content).digest('he
 
 const cache = {
     get_path: key => path.resolve(test_path, 'Cache', key ? key : ''),
+    get_tmp_path: key => `${cache.get_path(key)}.tmp`,
     write: () => Promise.resolve(),
     read: () => Promise.resolve(),
     exist: () => Promise.reject()


### PR DESCRIPTION
Split and renamed 'get_path' method in cache service to 'get_path' and 'get_tmp_path'.