### PR TITLE
Windows file system doesn't accept same extension names with insensitive case

### DIFF
--- a/test/am/unit/validator/asset.js
+++ b/test/am/unit/validator/asset.js
@@ -1,0 +1,19 @@
+/**
+* Copyright (C) 2015-2018 Starbreeze AB All Rights Reserved.
+*/
+
+'use strict';
+
+const should = require('should');
+const Validator = require('../../../../assetmanager/validator/asset');
+
+describe('Asset validator', function () {
+
+    it('Check some resources are found equivalents', function (done) {
+        const valid = new Validator({ adapter: {}, database: {} });
+        const res = valid.are_equivalent_refs(['a.ext', 'b.ext', 'a.eXt', 'a.EXT', 'c.ext', 'C.eXt', 'a.EXt', 'a.Ext', 'd.Ext', 'a.ext', 'w.Extss']);
+        should.deepEqual(res, ['a.eXt', 'a.EXT', 'a.EXt', 'a.Ext', 'a.ext', 'a.ext']);
+        done();
+    });
+
+});


### PR DESCRIPTION
[reference](https://superuser.com/questions/881804/case-sensitive-file-extensions-in-windows-and-linux)

Windows file system doesn't accept same extension names with insensitive case. Here is added a validator to ensure assets don't contain such use case.