### PR TITLE
Improve equivalent ref algorithm to support same filenames (insensitive case)

### DIFF
--- a/assetmanager/validator/asset.js
+++ b/assetmanager/validator/asset.js
@@ -147,16 +147,11 @@ function Asset(workspace) {
     this.is_valid_schema = asset => Validator.validate(asset, assets_schema_1_1_0);
 
     // this method checks if equivalent refs, same filename with sensitive case and same ext file with insensitive case
-    this.are_equivalent_refs = deps => deps.map((ref, index) => {
-            const ext_start_index = ref.lastIndexOf('.');
-            const name = ref.substring(0, ext_start_index);
-            const ext = ref.substring(ext_start_index + 1).toUpperCase();
-            return {
-                ref,
-                formatted_ref: `${name}.${ext}`
-            };
-        })
-            .sort((a, b) => a.formatted_ref.toUpperCase().localeCompare(b.formatted_ref.toUpperCase()))
+    this.are_equivalent_refs = deps => deps.map((ref, index) => ({
+            ref,
+            formatted_ref: ref.toUpperCase()
+        }))
+            .sort((a, b) => a.formatted_ref.localeCompare(b.formatted_ref))
             .filter((current, index, array) => {
                 const previous = array[index - 1];
                 const next = array[index + 1];

--- a/test/am/unit/validator/asset.js
+++ b/test/am/unit/validator/asset.js
@@ -16,20 +16,23 @@ describe('Asset validator', function () {
             'b.ext',
             'a.eXt',
             'a.EXT',
-            'c.ext',
             'C.eXt',
+            'c.ext',
             'a.EXt',
             'a.Ext',
             'd.Ext',
             'a.ext',
             'w.Extss'
         ]);
-        should.deepEqual(res, ['a.ext',
+        should.deepEqual(res, [
+            'a.ext',
             'a.eXt',
             'a.EXT',
             'a.EXt',
             'a.Ext',
-            'a.ext'
+            'a.ext',
+            'c.ext',
+            'C.eXt'
         ]);
         done();
     });
@@ -65,7 +68,8 @@ describe('Asset validator', function () {
             "/resources/a/f/3.random",
             "/resources/a/f/4.random",
             "/resources/a/f/5.random",
-            "/resources/a/f/6.random",
+            "/resources/a/f/fivE.rAndom",
+            "/resources/a/f/Five.ranDom",
             "/resources/a/f/7.random",
             "/resources/a/f/4.raNdom",
             "/resources/a/f/a/1.tga",
@@ -132,12 +136,14 @@ describe('Asset validator', function () {
             '/resources/a/d/1.jpeg',
             '/resources/a/f/4.random',
             '/resources/a/f/4.raNdom',
-            '/resources/a/f/a/1.TGa',
             '/resources/a/f/a/1.tga',
+            '/resources/a/f/a/1.TGa',
             '/resources/a/f/a/11.tga',
             '/resources/a/f/a/11.TGA',
-            '/resources/a/g/a/17.gif',
-            '/resources/a/g/a/17.GiF'
+            "/resources/a/f/fivE.rAndom",
+            "/resources/a/f/Five.ranDom",
+            '/resources/a/g/a/17.GiF',
+            '/resources/a/g/a/17.gif'
         ]);
         done();
     });


### PR DESCRIPTION
More than equivalent extensions, equivalent file names with insensitive case must be also spotted since Windows doesn't allow this.