### PR TITLE
Make sure download stream has time to close file when finished

### DIFF
--- a/lib/amazon-s3.js
+++ b/lib/amazon-s3.js
@@ -102,7 +102,7 @@ module.exports = (amazon_client, cache, config) => {
                         reject(err);
                     }
                     res.pipe(write_stream);
-                    res.on('end', () => {
+                    write_stream.on('finish', () => {
                         console.log('Done!');
                         resolve();
                     });


### PR DESCRIPTION
There might be a problem when req readable stream ends and resolves the promise. The file might not be closed at this time. Node documentation is blurry on this point. This stackoverflow [post](https://stackoverflow.com/questions/52107002/is-it-safe-to-assume-read-stream-end-event-gets-triggered-after-fs-writefiles) might help to get answers.