### PR TITLE
Remove guid from favorite service

### DIFF
--- a/assetmanager/asset.js
+++ b/assetmanager/asset.js
@@ -10,7 +10,6 @@
 /* jshint expr: true */
 
 'use strict';
-const Path = require('path').posix;
 
 const utilities = require('./utilities');
 const _error_outputs = require('../lib/errors')("Asset");
@@ -201,7 +200,7 @@ asset_model = workspace => {
                         directory_path = `${directory_path}/`;
                         const ref = `${workspace_utilities.relative_path_to_ref(directory_path)}/`;
                         return {
-                            url: Path.join("/contentbrowser/workspaces/", workspace.get_guid(), ref),
+                            url: `/contentbrowser/workspaces/${workspace.get_name()}${ref}`,
                             ref
                         };
                     });

--- a/assetmanager/favorite.js
+++ b/assetmanager/favorite.js
@@ -53,7 +53,6 @@ const save = (list) => {
     });
 };
 
-const _workspace_guid_regex = /^[a-zA-Z0-9]{40}$/;
 const _workspace_name_regex = /^[[\w\/\.-]{0,100}$/;
 const _workspace_file_uri_regex = /^file:\/\/\/.*$/;
 
@@ -62,10 +61,6 @@ module.exports = () => {
     const favorite = {
 
         list,
-
-        find_by_guid (guid) {
-            return list().find(item => item.guid === guid);
-        },
 
         find_by_file_uri (file_uri) {
             return list().find(item => item.file_uri === file_uri);
@@ -77,9 +72,7 @@ module.exports = () => {
 
         find (identifier) {
             if (typeof identifier === 'string') {
-                if (_workspace_guid_regex.test(identifier)) {
-                    return favorite.find_by_guid(identifier);
-                } else if (_workspace_name_regex.test(identifier)) {
+                if (_workspace_name_regex.test(identifier)) {
                     return favorite.find_by_name(identifier);
                 } else if (_workspace_file_uri_regex.test(identifier)) {
                     return favorite.find_by_file_uri(identifier);

--- a/assetmanager/subscription_presenter.js
+++ b/assetmanager/subscription_presenter.js
@@ -9,7 +9,7 @@ module.exports = {
         present: (subscription, workspace) => {
             return {
                 id: subscription.id,
-                url: '/assetmanager/workspaces/' + workspace.guid + '/subscriptions/' + subscription.id,
+                url: `/assetmanager/workspaces/${workspace.name}/subscriptions/${subscription.id}`,
                 type: subscription.type,
                 descriptor: subscription.descriptor,
             };

--- a/assetmanager/workspace.js
+++ b/assetmanager/workspace.js
@@ -433,7 +433,7 @@ module.exports = context => {
         if (identifiers && identifiers.file_uri) {
             return find_by_file_uri(identifiers.file_uri);
         } else {
-            return Promise.reject({error: _error_outputs.CORRUPT("Invalid workspace identifier")});
+            return Promise.reject({error: _error_outputs.NOTFOUND('workspace identifier in favorite list')});
         }
     }
 

--- a/assetmanager/workspace.js
+++ b/assetmanager/workspace.js
@@ -135,8 +135,8 @@ const Workspace = function (file_uri, context) {
             }
 
             // add other metadata to the resource
-            this.properties.resources_url = "/contentbrowser/workspaces/" + this.get_guid() + "/resources/";
-            this.properties.assets_url = "/contentbrowser/workspaces/" + this.get_guid() + "/assets/";
+            this.properties.resources_url = `/contentbrowser/workspaces/${this.get_name()}/resources/`;
+            this.properties.assets_url = `/contentbrowser/workspaces/${this.get_name()}/assets/`;
         }, err => {
             this.error = _error_outputs.NOTFOUND(err);
             throw this;

--- a/test/am/functional/controller/asset.js
+++ b/test/am/functional/controller/asset.js
@@ -44,7 +44,7 @@ describe('Run Asset related functional tests for the API', function () {
             };
             const asset_ref = '/assets/levels/test_002.level';
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -71,7 +71,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             const asset_ref = '/assets/levels';
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send()
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -102,7 +102,7 @@ describe('Run Asset related functional tests for the API', function () {
             };
             const asset_ref = '/assets/levels/random_ext_asset.' + random_extension;
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Accept", 'application/json')
                 .expect(201)
@@ -135,7 +135,7 @@ describe('Run Asset related functional tests for the API', function () {
             };
             const asset_ref = '/assets/levels/test_003.level';
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -169,7 +169,7 @@ describe('Run Asset related functional tests for the API', function () {
             };
             const asset_ref = '/assets/levels/test_006.level';
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -202,7 +202,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             const asset_ref = "/assets/levels/test_011.level";
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -226,7 +226,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             const asset_ref = "/assets/levels/test_011.level";
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -253,7 +253,7 @@ describe('Run Asset related functional tests for the API', function () {
             const asset_ref = "/assets/levels/test_011.level";
 
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -351,7 +351,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             const new_asset_ref = '/assets/levels/test/004/test_004.level';
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), 'rename', test_util.get_test_level().meta.ref))
+                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), 'rename', test_util.get_test_level().meta.ref))
                 .send({ new: new_asset_ref})
                 .set("Content-Type", "application/vnd.bilrost.asset+json")
                 .set("Accept", "application/json")
@@ -405,7 +405,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             const new_asset_ref = '/assets/levels/test/004/test_004.level';
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), 'rename', '/assets/unvalid'))
+                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), 'rename', '/assets/unvalid'))
                 .send({ new: new_asset_ref})
                 .set("Content-Type", "application/vnd.bilrost.asset+json")
                 .set("Accept", 'application/json')
@@ -423,7 +423,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             const new_asset_ref = '/assets/levels/test/004/test_004.level';
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), 'rename', new_asset_ref))
+                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), 'rename', new_asset_ref))
                 .send({ new: new_asset_ref})
                 .set("Content-Type", "application/vnd.bilrost.asset+json")
                 .set("Accept", 'application/json')
@@ -441,7 +441,7 @@ describe('Run Asset related functional tests for the API', function () {
         it('Cannot rename an unexisted asset', function(done){
 
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), 'rename', test_003.meta.ref))
+                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), 'rename', test_003.meta.ref))
                 .send({ new: '/invalid' })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -459,7 +459,7 @@ describe('Run Asset related functional tests for the API', function () {
         it('Cannot rename an asset with invalid content-type header', function(done){
 
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), 'rename', test_003.meta.ref))
+                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), 'rename', test_003.meta.ref))
                 .send({ new: '/invalid' })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -489,7 +489,7 @@ describe('Run Asset related functional tests for the API', function () {
             };
 
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), test_util.get_test_level().meta.ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), test_util.get_test_level().meta.ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -520,7 +520,7 @@ describe('Run Asset related functional tests for the API', function () {
             };
 
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), test_util.get_test_level().meta.ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), test_util.get_test_level().meta.ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -548,7 +548,7 @@ describe('Run Asset related functional tests for the API', function () {
             const modified = test_util.read_asset_file(test_util.get_test_level().meta.ref).meta.modified;
 
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), test_util.get_test_level().meta.ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), test_util.get_test_level().meta.ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -576,7 +576,7 @@ describe('Run Asset related functional tests for the API', function () {
             const modified = test_util.read_asset_file(test_util.get_test_level().meta.ref).meta.modified;
 
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), test_util.get_test_level().meta.ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), test_util.get_test_level().meta.ref))
                 .send(asset)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -600,7 +600,7 @@ describe('Run Asset related functional tests for the API', function () {
             const asset_path = path.join(test_util.get_eloise_path(), '.bilrost', test_util.get_test_level().meta.ref);
 
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), test_util.get_test_level().meta.ref))
+                .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), test_util.get_test_level().meta.ref))
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .set("Last-Modified", test_util.get_test_level().meta.modified)
@@ -627,7 +627,7 @@ describe('Run Asset related functional tests for the API', function () {
 
             test_util.remove_resource_file("/test/test");
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), ref))
+                .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), ref))
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .set("Last-Modified", test_util.get_test_level().meta.modified)
@@ -647,7 +647,7 @@ describe('Run Asset related functional tests for the API', function () {
         it('Cannot delete an asset with an not unexisted ref', function(done){
 
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), 'assets/invalid'))
+                .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), 'assets/invalid'))
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .set("Last-Modified", test_util.get_test_level().meta.modified)
@@ -686,7 +686,7 @@ describe('Run Asset related functional tests for the API', function () {
             test_util.get_database().add(reference_asset).then(() => {
 
                 test_util.client
-                    .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), test_util.get_test_level().meta.ref))
+                    .delete(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), test_util.get_test_level().meta.ref))
                     .set("Content-Type", "application/json")
                     .set("Accept", 'application/json')
                     .set("Last-Modified", test_util.get_test_level().meta.modified)

--- a/test/am/functional/controller/big_asset.js
+++ b/test/am/functional/controller/big_asset.js
@@ -70,7 +70,7 @@ describe('Run Asset related functional tests for the API', function () {
             const heap_size = v8.getHeapStatistics().total_heap_size;
 
             test_util.client
-                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), asset_ref))
+                .put(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), asset_ref))
                 .send(asset)
                 .set("Content-Type", "application/vnd.bilrost.level+json")
                 .set("Accept", 'application/json')

--- a/test/am/functional/controller/browse.js
+++ b/test/am/functional/controller/browse.js
@@ -179,7 +179,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
         after("Remove example3 workspace settings", function (done) {
 
-            favorite.remove(test_util.get_example3_workspace().guid)
+            favorite.remove(test_util.get_example3_workspace().name)
                 .then(() => done())
                 .catch(done);
 
@@ -208,7 +208,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Can\'t retrieve example3 workspace by name since not referenced in favorite list", function(done){
 
             test_util.client
-                .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().guid}`)
+                .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().name}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -246,7 +246,6 @@ describe('Run Content Browser related test for content browser api', function ()
 
         it("Can't retrieve example3 workspace with its associated invalid statuses", function(done){
             favorite.add({
-                guid: test_util.get_example3_workspace().guid,
                 name: test_util.get_example3_workspace().name,
                 file_uri: test_util.get_example3_file_uri()
             }).then(function () {
@@ -302,8 +301,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
         it("Retrieve example3 workspace after changing its associated statuses to valid", function(done){
 
-            favorite.update(test_util.get_example3_workspace().guid, {
-                guid: test_util.get_example3_workspace().guid,
+            favorite.update(test_util.get_example3_workspace().name, {
                 name: test_util.get_example3_workspace().name,
                 url: test_util.get_example3_file_uri()
             }).then(function () {
@@ -416,7 +414,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
         it("Can't retrieve example3 workspace since it has been removed from favorite list", function(done){
 
-            favorite.remove(test_util.get_example3_workspace().guid)
+            favorite.remove(test_util.get_example3_workspace().name)
                 .then(function () {
                     test_util.client
                         .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().name}`)

--- a/test/am/functional/controller/browse.js
+++ b/test/am/functional/controller/browse.js
@@ -208,7 +208,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Can\'t retrieve example3 workspace by name since not referenced in favorite list", function(done){
 
             test_util.client
-                .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().name}`)
+                .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().guid}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -226,7 +226,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Retrieve example3 workspace without being referenced in favorite list using file uri identifier", function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/' + encodeURIComponent(test_util.get_example3_file_uri()))
+                .get(`/contentbrowser/workspaces/${encodeURIComponent(test_util.get_example3_file_uri())}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -245,7 +245,6 @@ describe('Run Content Browser related test for content browser api', function ()
         });
 
         it("Can't retrieve example3 workspace with its associated invalid statuses", function(done){
-
             favorite.add({
                 guid: test_util.get_example3_workspace().guid,
                 name: test_util.get_example3_workspace().name,
@@ -269,7 +268,7 @@ describe('Run Content Browser related test for content browser api', function ()
                 ];
                 fs.writeJsonSync(workspace_example_3_path, workspace);
                 test_util.client
-                    .get('/contentbrowser/workspaces/' + test_util.get_example3_workspace().guid)
+                    .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().name}`)
                     .set("Content-Type", "application/json")
                     .set("Accept", 'application/json')
                     .expect(403)
@@ -326,7 +325,7 @@ describe('Run Content Browser related test for content browser api', function ()
                 ];
                 fs.writeJsonSync(workspace_example_3_path, workspace);
                 test_util.client
-                    .get('/contentbrowser/workspaces/' + test_util.get_example3_workspace().guid)
+                    .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().name}`)
                     .set("Content-Type", "application/json")
                     .set("Accept", 'application/json')
                     .expect("Content-Type", "application/json")
@@ -399,7 +398,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Check "filter" query paramaters for retrieving workspaces', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/?name='+ test_util.get_bob_workspace().name)
+                .get(`/contentbrowser/workspaces/?name=${test_util.get_bob_workspace().name}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -420,10 +419,10 @@ describe('Run Content Browser related test for content browser api', function ()
             favorite.remove(test_util.get_example3_workspace().guid)
                 .then(function () {
                     test_util.client
-                        .get('/contentbrowser/workspaces/' + test_util.get_example3_workspace().guid)
+                        .get(`/contentbrowser/workspaces/${test_util.get_example3_workspace().name}`)
                         .set("Content-Type", "application/json")
                         .set("Accept", 'application/json')
-                        .expect(400)
+                        .expect(404)
                         .end((err, res) => {
                             if (err) {
                                 return done({ error: err.toString(), status: res.status, body: res.body });
@@ -441,25 +440,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
         it('retrieves example2 by name', (done) => {
             test_util.client
-                .get('/contentbrowser/workspaces/'+ example2.name)
-                .set("Content-Type", "application/json")
-                .set("Accept", 'application/json')
-                .expect("Content-Type", "application/json")
-                .expect(200)
-                .end((err, res) => {
-                    const obj = res.body;
-                    if (err) {
-                        return done({ error: err.toString(), status: res.status, body: obj });
-                    }
-                    obj.items.should.have.lengthOf(1);
-                    obj.items.should.containDeep([example2]);
-                    done();
-                });
-        });
-
-        it('retrieves example2 by guid', (done) => {
-            test_util.client
-                .get('/contentbrowser/workspaces/'+ example2.guid)
+                .get(`/contentbrowser/workspaces/${example2.name}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -477,7 +458,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
         it('retrieves example2 by file uri', (done) => {
             test_util.client
-                .get('/contentbrowser/workspaces/'+ encodeURIComponent(example2.file_uri))
+                .get(`/contentbrowser/workspaces/${encodeURIComponent(example2.file_uri)}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -494,11 +475,11 @@ describe('Run Content Browser related test for content browser api', function ()
         });
     });
 
-    describe('-- [GET] /contentbrowser/workspaces/{workspace_guid}/assets/', function () {
+    describe('-- [GET] /contentbrowser/workspaces/{workspace_name}/assets/', function () {
 
         it('Retrieve test asset', function(done){
             test_util.client
-                .get(path.join('/contentbrowser/workspaces/', test_util.get_bob_workspace().guid, test_util.get_test_level().meta.ref))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}${test_util.get_test_level().meta.ref}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/vnd.bilrost.level+json")
@@ -517,7 +498,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Don't retrieve unknown asset", function(done) {
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+ test_util.get_bob_workspace().name +'/assets/unknown')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/unknown`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -554,7 +535,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Check "paging" query paramaters for retrieving assets in prefab namespace', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/' + test_util.get_bob_workspace().guid + '/assets/prefab/?maxResults=1')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/prefab/?maxResults=1`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -588,7 +569,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Check "filter" query paramaters for retrieving assets in prefab namespace', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/prefab/?ref=*')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/prefab/?ref=*`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -608,7 +589,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search one asset', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q=mall')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=mall`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -628,7 +609,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search all levels', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent(".level"))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent(".level")}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -648,7 +629,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search all levels OR test prefab', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent(".level OR test tag: TEST"))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent(".level OR test tag: TEST")}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -668,7 +649,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search all levels OR test prefab', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent("type: level AND NOT (1_1_0 OR tag: TEST)"))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent("type: level AND NOT (1_1_0 OR tag: TEST)")}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -687,7 +668,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search all assets created between 2000 and 2020', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent('created:.. 2000 2040 AND comment: "test asset!"'))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent('created:.. 2000 2040 AND comment: "test asset!"')}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -707,7 +688,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search for asset with specific dependency', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent('dependency: /resources/test/test'))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent('dependency: /resources/test/test')}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -727,7 +708,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Find 0 results searching for asset with invalid dependency', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent('dependency: /resources/test/test.invalid'))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent('dependency: /resources/test/test.invalid')}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -747,7 +728,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Search for asset with specific tag', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent('tag: TEST'))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent('tag: TEST')}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -767,7 +748,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Find 0 results searching for asset with invalid tag', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/assets/?q='+encodeURIComponent('tag: TESTWRONG'))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/assets/?q=${encodeURIComponent('tag: TESTWRONG')}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -786,12 +767,12 @@ describe('Run Content Browser related test for content browser api', function ()
 
     });
 
-    describe('-- [GET] /contentbrowser/workspaces/{workspace_guid}/resources/', function(){
+    describe('-- [GET] /contentbrowser/workspaces/{workspace_name}/resources/', function(){
 
         after("Remove example2 workspace", function (done) {
 
             test_util.client
-                .delete('/assetmanager/workspaces/'+test_util.get_bob_workspace().guid)
+                .delete(`/assetmanager/workspaces/${test_util.get_bob_workspace().name}`)
                 .set("accept", "application/json")
                 .expect(200)
                 .end((err, res) => {
@@ -808,7 +789,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Retrieve mall resource from example2 workspace using name identifier', function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/resources/mall/mall_demo')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/resources/mall/mall_demo`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -828,7 +809,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Don't retrieve unknown resource", function(done) {
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/resources/unknown')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/resources/unknown`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -846,7 +827,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Don't retrieve unknown resource", function(done) {
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/resources/assets')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/resources/assets`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -864,7 +845,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/resources/')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/resources/`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -885,7 +866,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it('Check "paging" query paramaters for retrieving resources in root folder', function (done) {
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/resources/?maxResults=1')
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/resources/?maxResults=1`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
@@ -920,7 +901,7 @@ describe('Run Content Browser related test for content browser api', function ()
         it("Retrieve resources in root folder with search query", function(done){
 
             test_util.client
-                .get('/contentbrowser/workspaces/'+test_util.get_bob_workspace().guid+'/resources/?q='+encodeURIComponent("test OR mall"))
+                .get(`/contentbrowser/workspaces/${test_util.get_bob_workspace().name}/resources/?q=${encodeURIComponent("test OR mall")}`)
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")

--- a/test/am/functional/controller/populate_workspace.js
+++ b/test/am/functional/controller/populate_workspace.js
@@ -8,7 +8,6 @@
 global.debug = true;
 
 const should = require('should');
-const path = require('path').posix;
 const Test_util = require('../../../util/test_util');
 
 var test_util = new Test_util('populate_workspace', 'good_repo');
@@ -48,7 +47,6 @@ describe('Run Workspace related functional tests for the API', function () {
             obj = test_util.get_example_project();
         });
 
-        let workspace_guid;
         it('Populate a workspace', function (done) {
             this.timeout(8*this.timeout());
             test_util.client
@@ -70,13 +68,12 @@ describe('Run Workspace related functional tests for the API', function () {
                     obj.should.be.an.Object;
                     should.equal(test_util.does_workspace_exist('good_repo'), true);
                     should.equal(test_util.does_workspace_internals_valid('good_repo'), true);
-                    workspace_guid = res.body.guid;
                     done();
                 });
         });
         it('Delete well the populated workspace', function(done){
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', workspace_guid))
+                .delete(`/assetmanager/workspaces/${test_util.get_example_project().name}`)
                 .send()
                 .set("Accept", 'application/json')
                 .set("Content-Type", "application/json")

--- a/test/am/functional/controller/s3_vcs.js
+++ b/test/am/functional/controller/s3_vcs.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const should = require('should');
-const path = require('path').posix;
 const Test_util = require('../../../util/test_util');
 const start_bilrost_client = require('../../../util/local_bilrost_client');
 
@@ -41,20 +40,19 @@ describe('Run Version Control related functional tests for the API', function ()
             obj = test_util.get_example_project();
         });
 
-        let workspace_guid;
         let new_subscription_id;
         let new_subscription_url;
-
+        const workspace_name = test_util.get_example_project().name;
         it('Create a Workspace by cloning repository', function (done) {
             this.timeout(8*this.timeout());
             test_util.client
                 .post('/assetmanager/workspaces')
                 .send({
                     file_uri: test_util.get_ken_file_uri(),
-                    name: test_util.get_example_project().name,
+                    name: workspace_name,
                     description: test_util.get_example_project().description.comment,
                     organization: test_util.get_example_project().owner.login,
-                    project_name: test_util.get_example_project().name,
+                    project_name: workspace_name,
                     branch: 'production_repo',
                 })
                 .set("Content-Type", "application/json")
@@ -68,7 +66,6 @@ describe('Run Version Control related functional tests for the API', function ()
                     let obj = test_util.get_favorite().search(test_util.get_ken_file_uri());
                     // jshint expr:true
                     obj.should.be.an.Object;
-                    workspace_guid = res.body.guid;
                     done();
                 });
         });
@@ -76,7 +73,7 @@ describe('Run Version Control related functional tests for the API', function ()
         it('Add Asset Subscription to Workspace', function (done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/subscriptions'))
+                .post(`/assetmanager/workspaces/${workspace_name}/subscriptions`)
                 .send({
                         type: "ASSET",
                         descriptor: "/assets/test_1_1_0.level"
@@ -100,7 +97,7 @@ describe('Run Version Control related functional tests for the API', function ()
         it('Add Namespace Subscription to Workspace', function (done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/subscriptions'))
+                .post(`/assetmanager/workspaces/${workspace_name}/subscriptions`)
                 .send({
                         type: "NAMESPACE",
                         descriptor: "/assets/prefab/"
@@ -119,7 +116,7 @@ describe('Run Version Control related functional tests for the API', function ()
         it('Add Search Subscription to Workspace', function (done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/subscriptions'))
+                .post(`/assetmanager/workspaces/${workspace_name}/subscriptions`)
                 .send({
                         type: "SEARCH",
                         descriptor: "test created:> 2004 type: prefab"
@@ -141,7 +138,7 @@ describe('Run Version Control related functional tests for the API', function ()
 
         it('Fail to add invalid Namespace Subscription to Workspace', function (done) {
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/subscriptions'))
+                .post(`/assetmanager/workspaces/${workspace_name}/subscriptions`)
                 .send({
                         type: "NAMESPACE",
                         descriptor: "/invalid"
@@ -157,7 +154,7 @@ describe('Run Version Control related functional tests for the API', function ()
 
         it('Get Subscription List with most recent entry', function (done) {
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', workspace_guid, '/subscriptions'))
+                .get(`/assetmanager/workspaces/${workspace_name}/subscriptions`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -177,7 +174,7 @@ describe('Run Version Control related functional tests for the API', function ()
             test_util.remove_asset_file('/assets/test_1_1_0.level');
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/stage', '/assets/test_1_1_0.level'))
+                .post(`/assetmanager/workspaces/${workspace_name}/stage/assets/test_1_1_0.level`)
                 .send()
                 .set("Accept", 'application/json')
                 .expect(200)
@@ -195,7 +192,7 @@ describe('Run Version Control related functional tests for the API', function ()
         it('Succeed to add non subscribed Asset to Workspace Stage', function (done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/stage', '/assets/levels/test_001.level'))
+                .post(`/assetmanager/workspaces/${workspace_name}/stage/assets/levels/test_001.level`)
                 .send()
                 .set("Accept", 'application/json')
                 .expect(200)
@@ -210,7 +207,7 @@ describe('Run Version Control related functional tests for the API', function ()
         it('Fail to add non existent Asset to Workspace Stage', function (done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', workspace_guid, '/stage', '/invalid/path'))
+                .post(`/assetmanager/workspaces/${workspace_name}/stage/invalid/path`)
                 .send()
                 .set("Accept", 'application/json')
                 .expect(200)
@@ -224,7 +221,7 @@ describe('Run Version Control related functional tests for the API', function ()
 
         it('Get Workspace Stage with most recent entry', function (done) {
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', workspace_guid, '/stage'))
+                .get(`/assetmanager/workspaces/${workspace_name}/stage`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -240,7 +237,7 @@ describe('Run Version Control related functional tests for the API', function ()
 
         it('Delete Asset from Workspace Stage', function (done) {
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', workspace_guid, '/stage', '/assets/test_1_1_0.level'))
+                .delete(`/assetmanager/workspaces/${workspace_name}/stage/assets/test_1_1_0.level`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -274,7 +271,7 @@ describe('Run Version Control related functional tests for the API', function ()
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
 
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', workspace_guid, '/commits?maxResults=3'))
+                .get(`/assetmanager/workspaces/${workspace_name}/commits?maxResults=3`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -295,7 +292,7 @@ describe('Run Version Control related functional tests for the API', function ()
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
 
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', workspace_guid, '/commits', '/assets/test_1_1_0.level'))
+                .get(`/assetmanager/workspaces/${workspace_name}/commits/assets/test_1_1_0.level`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -315,7 +312,7 @@ describe('Run Version Control related functional tests for the API', function ()
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
 
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', workspace_guid, '/commits?start_at_revision=r238&maxResults=2'))
+                .get(`/assetmanager/workspaces/${workspace_name}/commits?start_at_revision=r238&maxResults=2`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -335,7 +332,7 @@ describe('Run Version Control related functional tests for the API', function ()
 
         it('Hard delete the initialized Workspace', function(done){
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', workspace_guid))
+                .delete(`/assetmanager/workspaces/${workspace_name}`)
                 .send({ hard_delete: true })
                 .set("Accept", 'application/json')
                 .set("Content-Type", "application/json")

--- a/test/am/functional/controller/status.js
+++ b/test/am/functional/controller/status.js
@@ -31,7 +31,7 @@ describe('Run Status related functional tests for the API', function () {
         it('Retrieve general Status of the Workspace', function(done) {
             this.timeout(7*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), '/status'))
+                .get(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), '/status'))
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -47,7 +47,7 @@ describe('Run Status related functional tests for the API', function () {
         it('Add Asset Subscription to Workspace', function (done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), '/subscriptions'))
+                .post(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), '/subscriptions'))
                 .send({
                         type: "ASSET",
                         descriptor: "/assets/test_1_1_0.level"
@@ -69,7 +69,7 @@ describe('Run Status related functional tests for the API', function () {
         it('Retrieve status of specific Asset from Workspace', function(done) {
             this.timeout(5*this.timeout()); // = 5 * default = 5 * 2000 = 10000
             test_util.client
-                .get(path.join('/assetmanager/workspaces/', test_util.get_workspace_guid(), '/status', '/assets/test_1_1_0.level'))
+                .get(path.join('/assetmanager/workspaces/', test_util.get_workspace_name(), '/status', '/assets/test_1_1_0.level'))
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {

--- a/test/am/functional/controller/workspace.js
+++ b/test/am/functional/controller/workspace.js
@@ -132,7 +132,7 @@ describe('Run Workspace related functional tests for the API', function () {
         it('Remove "example1" Workspace from favorites', function(done){
 
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', test_util.get_alice_workspace().guid, 'favorites'))
+                .delete(`/assetmanager/workspaces/${test_util.get_alice_workspace().name}/favorites`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -148,7 +148,7 @@ describe('Run Workspace related functional tests for the API', function () {
         it('Remove "example2" Workspace from favorites', function(done){
 
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', test_util.get_bob_workspace().guid, 'favorites'))
+                .delete(`/assetmanager/workspaces/${test_util.get_bob_workspace().name}/favorites`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -164,7 +164,7 @@ describe('Run Workspace related functional tests for the API', function () {
         it('Check workspace removal is idempotent', function(done){
             test_util.get_favorite().search(test_util.get_bob_file_uri()).should.equal(false);
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', test_util.get_alice_workspace().guid, 'favorites'))
+                .delete(`/assetmanager/workspaces/${test_util.get_bob_workspace().name}/favorites`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -187,7 +187,6 @@ describe('Run Workspace related functional tests for the API', function () {
             obj = test_util.get_example_project();
         });
 
-        let workspace_guid;
         it('Create a workspace', function (done) {
             this.timeout(8*this.timeout());
             test_util.client
@@ -212,7 +211,6 @@ describe('Run Workspace related functional tests for the API', function () {
                     // jshint expr:true
                     obj.should.be.an.Object;
                     should.equal(test_util.does_workspace_exist('new_workspace_v2'), true);
-                    workspace_guid = res.body.guid;
                     done();
                 });
         });
@@ -239,7 +237,7 @@ describe('Run Workspace related functional tests for the API', function () {
 
         it('Forget the copied Workspace from favorite list', function(done){
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', workspace_guid, 'favorites'))
+                .delete(`/assetmanager/workspaces/${encodeURIComponent(test_util.get_carol_file_uri())}/favorites`)
                 .send()
                 .set("Accept", 'application/json')
                 .set("Content-Type", "application/json")
@@ -274,7 +272,7 @@ describe('Run Workspace related functional tests for the API', function () {
 
         it('Delete the created Workspace', function(done){
             test_util.client
-                .delete(path.join('/assetmanager/workspaces/', workspace_guid))
+                .delete(`/assetmanager/workspaces/${encodeURIComponent(test_util.get_carol_file_uri())}`)
                 .send()
                 .set("Accept", 'application/json')
                 .set("Content-Type", "application/json")

--- a/test/am/functional/model/asset.js
+++ b/test/am/functional/model/asset.js
@@ -48,7 +48,6 @@ const test_level = {
 };
 
 const workspace_identifiers = {
-    guid: "e39d0f72c81c445ba801dsssssss45219sddsdss",
     name: "test-workspace",
     file_uri: example_file_uri,
     version_id: "5"

--- a/test/am/functional/model/asset.js
+++ b/test/am/functional/model/asset.js
@@ -104,7 +104,7 @@ describe('Run set of test for asset management methods', function () {
 
     after("Flush search index map", function (done) {
         workspace.database.close()
-            .then(() => favorite.remove(workspace_identifiers.guid))
+            .then(() => favorite.remove(workspace_identifiers.name))
             .then(done, done);
     });
 

--- a/test/am/unit/asset.js
+++ b/test/am/unit/asset.js
@@ -127,7 +127,7 @@ describe('Run set of test for asset management methods', function () {
             cache: {}
         });
         let this_workspace;
-        before(() => Workspace.find(test_util.eloise.guid)
+        before(() => Workspace.find(test_util.eloise.name)
             .then(wrkspc => this_workspace = wrkspc));
 
         it('retrieves test asset', function() {

--- a/test/am/unit/favorite.js
+++ b/test/am/unit/favorite.js
@@ -10,13 +10,11 @@ describe('Favorite object', function () {
     const favorite = require('../../../assetmanager/favorite')();
 
     const example_1 = {
-        "guid": "0001",
         "name": "example_1",
         "file_uri": "file:///a/b/example_1"
     };
 
     const example_2 = {
-        "guid": "002",
         "name": "example_2",
         "file_uri": "file:///a/b/example2"
     };
@@ -52,21 +50,16 @@ describe('Favorite object', function () {
     });
 
     describe("Removing", function(){
-        it('removes a workspace index by guid', function(){
-            return favorite.remove(example_1.guid).then(() => {
+
+        it('removes a workspace by file_uri', function(){
+            return favorite.remove(example_2.file_uri).then(() => {
                 return favorite.list().length.should.equal(1);
             });
         });
 
-        it('removes a workspace by file_uri', function(){
-            return favorite.remove(example_2.file_uri).then(() => {
-                return favorite.list().length.should.equal(0);
-            });
-        });
-
         it('doesnt complain removing unexisting workspaces', function () {
-            return favorite.remove(example_1.guid).then(() => {
-                return favorite.list().length.should.equal(0);
+            return favorite.remove(example_2.file_uri).then(() => {
+                return favorite.list().length.should.equal(1);
             });
         });
 
@@ -75,9 +68,6 @@ describe('Favorite object', function () {
     describe('Finding', () => {
         before(function () {
             return favorite.flush().then(() => favorite.add(example_1));
-        });
-        it('finds by guid', () => {
-            favorite.find_by_guid(example_1.guid).should.equal(example_1);
         });
         it('finds by name', () => {
             favorite.find_by_name(example_1.name).should.equal(example_1);

--- a/test/am/unit/workspace.js
+++ b/test/am/unit/workspace.js
@@ -110,11 +110,9 @@ describe('Workspace object', function () {
 
     before('Insert workspace references to favorite list', function(){
         return favorite.add({
-            guid: example1_workspace.guid,
             name: example1_workspace.name,
             file_uri: example1_workspace.file_uri
         }).then(favorite.add({
-            guid: example2_workspace.guid,
             name: example2_workspace.name,
             file_uri: example2_workspace.file_uri
         }));

--- a/test/integration/db.js
+++ b/test/integration/db.js
@@ -63,7 +63,7 @@ describe('Check database behaviors', function () {
                 .then(() => test_util.add_eloise_to_favorite())
                 .then(() => {
                     test_util.client
-                        .get('/contentbrowser/workspaces/' + test_util.get_workspace_guid() + '/assets/')
+                        .get('/contentbrowser/workspaces/' + test_util.get_workspace_name() + '/assets/')
                         .set("Content-Type", "application/json")
                         .set("Accept", 'application/json')
                         .expect("Content-Type", "application/json")
@@ -109,7 +109,7 @@ describe('Check database behaviors', function () {
 
         it('List persisted asset', function(done){
             test_util.client
-                .get('/contentbrowser/workspaces/' + test_util.get_workspace_guid() + '/assets/')
+                .get('/contentbrowser/workspaces/' + test_util.get_workspace_name() + '/assets/')
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")

--- a/test/util/test_util.js
+++ b/test/util/test_util.js
@@ -326,7 +326,7 @@ class Test_util {
 
         var example3_workspace = JSON.parse(JSON.stringify(this.get_bob_workspace()));
         example3_workspace.guid = 'e39d0f72czzz445ba8014f3999f576c7sdadswgg';
-        example3_workspace.name = 'feat/example3_workspace';
+        example3_workspace.name = 'example3_workspace';
 
         fs.copySync(this.get_eloise_path(), workspace3_path);
         this.create_workspace_properties_file(workspace3_path, example3_workspace);

--- a/test/util/test_util.js
+++ b/test/util/test_util.js
@@ -45,9 +45,10 @@ class Test_util {
         fs.mkdirpSync(this.get_fixtures());
 
         this.git_ssh_url = 'git@github.com:fl4re/open_bilrost_test_project.git';
+        this.eloise_workspace_name = 'test-workspace';
         this.eloise = {
             guid: 'e39d0f72c81c445ba801dsssssss45219sddsdss',
-            name: 'test-workspace',
+            name: this.eloise_workspace_name,
             description: 'This is your first workspace cloned from DLC_1 branch !',
             version: '2.0.0',
             pushed_at: '2011-01-26T19:01:12Z',
@@ -338,7 +339,7 @@ class Test_util {
 
     remove_fixtures (done) {
         this.client
-            .delete('/assetmanager/workspaces/'+this.get_workspace_guid()+'/favorites')
+            .delete(`/assetmanager/workspaces/${this.get_workspace_name()}/favorites`)
             .set('accept', 'application/json')
             .end((err, res) => {
                 should.not.exist(err);
@@ -372,7 +373,7 @@ class Test_util {
     get_eloise_identifiers () {
         return {
             file_uri: this.get_eloise_file_uri(),
-            name: 'eloise',
+            name: this.eloise_workspace_name,
             guid: this.eloise.guid
         };
     }
@@ -447,6 +448,10 @@ class Test_util {
 
     get_s3_example_project () {
         return this.s3_example_project;
+    }
+
+    get_workspace_name () {
+        return this.eloise_workspace_name;
     }
 
     get_workspace_guid () {


### PR DESCRIPTION
guid identifier was used for referencing a workspace in favorite. This PR deprecates this identifier that is not used anymore and complicates code for no reasons.