### PR TITLE
[VRSDK-1567] Remove hardcoded file uri in workpsace resource

### DIFF
--- a/assetmanager/workspace_presenter.js
+++ b/assetmanager/workspace_presenter.js
@@ -30,7 +30,6 @@ module.exports = {
                 created_at: properties.created_at,
                 updated_at: properties.updated_at,
                 type: properties.type,
-                file_uri: properties.file_uri,
                 subscriptions: properties.subscriptions,
                 stage: properties.stage,
                 statuses: properties.statuses,

--- a/test/integration/browse.js
+++ b/test/integration/browse.js
@@ -439,7 +439,7 @@ describe('Run Content Browser related test for content browser api', function ()
     describe('-- [GET] /contentbrowser/workspaces/{id}', function() {
 
         it('retrieves example2 by name', (done) => {
-            const example2 = test_util.get_bob_workspace();
+            const example2 = JSON.parse(JSON.stringify(test_util.get_bob_workspace()));
             client
                 .get(`/contentbrowser/workspaces/${example2.name}`)
                 .set("Content-Type", "application/json")
@@ -452,13 +452,14 @@ describe('Run Content Browser related test for content browser api', function ()
                         return done({ error: err.toString(), status: res.status, body: obj });
                     }
                     obj.items.should.have.lengthOf(1);
+                    delete example2.file_uri;
                     obj.items.should.containDeep([example2]);
                     done();
                 });
         });
 
         it('retrieves example2 by file uri', (done) => {
-            const example2 = test_util.get_bob_workspace();
+            const example2 = JSON.parse(JSON.stringify(test_util.get_bob_workspace()));
             client
                 .get(`/contentbrowser/workspaces/${encodeURIComponent(example2.file_uri)}`)
                 .set("Content-Type", "application/json")
@@ -471,6 +472,7 @@ describe('Run Content Browser related test for content browser api', function ()
                         return done({ error: err.toString(), status: res.status, body: obj });
                     }
                     obj.items.should.have.lengthOf(1);
+                    delete example2.file_uri;
                     obj.items.should.containDeep([example2]);
                     done();
                 });


### PR DESCRIPTION
Fix for this [jira ticket](https://jira.starbreeze.com/browse/VRSDK-1567?jql=project%20%3D%20VRSDK%20AND%20component%20%3D%20Bilrost). Bilrost doesn't need to reference workspace location in its resource as a workspace is capable to find out dynamically the path/file_uri at instanciation.