### PR TITLE
Common main and dependency reference in assets

### DIFF
--- a/test/util/workspace.js
+++ b/test/util/workspace.js
@@ -69,6 +69,7 @@ module.exports = (name, fixture) => {
         return asset;
     };
     const read_asset = ref => fs.readJsonSync(utilities.ref_to_absolute_path(ref, get_path()));
+    const get_last_modified = asset => read_asset(asset).meta.modified;
     const remove_asset = ref => fs.removeSync(utilities.ref_to_absolute_path(ref, get_path()));
     const create_resource = relative => fs.outputFileSync(_path.join(get_path(), relative));
     const remove_resource = relative => fs.removeSync(_path.join(get_path(), relative));
@@ -116,6 +117,7 @@ module.exports = (name, fixture) => {
         format_asset,
         create_asset,
         read_asset,
+        get_last_modified,
         remove_asset,
         create_resource,
         remove_resource,


### PR DESCRIPTION
Dependency and main references can collide.  Ensure finding common reference in main and dependency asset values is not valid. The main value is preserved and dependency discarded in the case of an asset update with these common assignments