### PR TITLE
Don't parse body in put and post

### DIFF
--- a/controllers/asset.js
+++ b/controllers/asset.js
@@ -107,28 +107,22 @@ module.exports = function(server, context) {
         const workspace_identifier = sanitize(req.params[0]);
         const asset_ref = sanitize(req.params[1]);
         const modified = sanitize(req.headers['last-modified']);
-        const is_body_a_json_to_parse = typeof req.body === 'string' || req.body instanceof Buffer;
-        let asset_representation;
-        try {
-            asset_representation = is_body_a_json_to_parse ? JSON.parse(req.body) : req.body;
-        } catch (err) {
-            return handler.handleError(errors.CORRUPT(err));
-        }
+        const asset_representation = req.body;
         const workspace = await _workspace.find(workspace_identifier);
         try {
             await workspace.check_overall_validation();
             const asset = await workspace.asset.create(asset_ref, asset_representation);
-            return handler.sendJSON(asset, 201);
+            handler.sendJSON(asset, 201);
         } catch (error) {
             if (error && error.statusCode === 403) {
                 try {
                     const asset = await workspace.asset.replace(asset_ref, asset_representation, modified);
-                    return handler.sendJSON(asset, 200);
+                    handler.sendJSON(asset, 200);
                 } catch (error) {
-                    return handler.handleError(error);
+                    handler.handleError(error);
                 }
             } else {
-                return handler.handleError(error);
+                handler.handleError(error);
             }
         }
     });
@@ -138,12 +132,7 @@ module.exports = function(server, context) {
         const workspace_identifier = sanitize(req.params[0]);
         const asset_ref = sanitize(req.params[1]);
         const modified = sanitize(req.headers['last-modified']);
-        var new_asset_ref;
-        try {
-            new_asset_ref = JSON.parse(req.body).new;
-        } catch (err) {
-            return handler.handleError(errors.CORRUPT(err));
-        }
+        const new_asset_ref = req.body.new;
         let workspace;
         try {
             workspace = await _workspace.find(workspace_identifier);

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ module.exports = function(options) {
     server.server.setTimeout(60000 * 60 * 10);
 
     server.use(restify.queryParser()); // split arguments in req.query
+    server.use(restify.bodyParser()); // split arguments in req.body
     server.use(restify.dateParser()); // parse dates into javascript date format
     restify.defaultResponseHeaders = false;
 

--- a/test/end-to-end/cli/use_case_1.js
+++ b/test/end-to-end/cli/use_case_1.js
@@ -80,7 +80,7 @@ describe('Integration tests --DO_NOT_RUN', function() {
             should.not.exist(error);
             // eslint-disable-next-line no-console
             console.log(stderr);
-            should.equal(stdout.match(/success/gi).length, 14);
+            should.equal(stdout.match(/success/gi).length, 15);
             git.read('/resources/alice_resource.txt', { rev: 'HEAD' })
                 .then(() => done('Alice resource still exist!'))
                 .catch(err => {

--- a/test/end-to-end/db.js
+++ b/test/end-to-end/db.js
@@ -33,7 +33,6 @@ describe('Check database behaviors', function() {
                 });
                 client
                     .get(`/contentbrowser/workspaces/${workspace.get_encoded_file_uri()}/assets/`)
-                    .set("Content-Type", "application/json")
                     .set("Accept", 'application/json')
                     .expect("Content-Type", "application/json")
                     .expect(200)
@@ -64,7 +63,6 @@ describe('Check database behaviors', function() {
         it('List persisted asset', function (done) {
             client
                 .get(`/contentbrowser/workspaces/${workspace.get_encoded_file_uri()}/assets/`)
-                .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
                 .expect(200)

--- a/test/integration/asset.js
+++ b/test/integration/asset.js
@@ -377,7 +377,7 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(`/assetmanager/workspaces/${workspace.get_encoded_file_uri()}/rename${test_level_asset.meta.ref}`)
                 .send({ new: new_asset_ref })
-                .set("Content-Type", "application/vnd.bilrost.asset+json")
+                .set("Content-Type", "application/json")
                 .set("Accept", "application/json")
                 .set("Last-Modified", workspace.read_asset(asset_ref).meta.modified)
                 .expect(200)
@@ -414,8 +414,8 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(path.join('/assetmanager/workspaces/', workspace.get_encoded_file_uri(), 'rename', '/assets/unvalid'))
                 .send({ new: new_asset_ref})
-                .set("Content-Type", "application/vnd.bilrost.asset+json")
-                .set("Accept", 'application/json')
+                .set("Content-Type", "application/json")
+                .set("Accept", "application/json")
                 .set("Last-Modified", workspace.format_asset().meta.modified)
                 .expect(404)
                 .end((err, res) => {
@@ -432,7 +432,7 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(path.join('/assetmanager/workspaces/', workspace.get_encoded_file_uri(), 'rename', new_asset_ref))
                 .send({ new: new_asset_ref})
-                .set("Content-Type", "application/vnd.bilrost.asset+json")
+                .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .set("Last-Modified", "2016-03-18T10:54:05.860Z")
                 .expect(412)
@@ -452,7 +452,7 @@ describe('Run Asset related functional tests for the API', function() {
                 .send({ new: '/invalid' })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
-                .set("Last-Modified", workspace.format_asset().meta.modified)
+                .set("Last-Modified", workspace.read_asset(test_003.meta.ref).meta.modified)
                 .expect(400)
                 .end((err, res) => {
                     if (err) {
@@ -468,10 +468,10 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(path.join('/assetmanager/workspaces/', workspace.get_encoded_file_uri(), 'rename', test_003.meta.ref))
                 .send({ new: '/invalid' })
-                .set("Content-Type", "application/json")
+                .set("Content-Type", "application/invalid/json")
                 .set("Accept", 'application/json')
-                .set("Last-Modified", workspace.format_asset().meta.modified)
-                .expect(400)
+                .set("Last-Modified", workspace.read_asset(test_003.meta.ref).meta.modified)
+                .expect(500)
                 .end((err, res) => {
                     if (err) {
                         return done({ error: err.toString(), status: res.status, body: res.body });
@@ -499,7 +499,7 @@ describe('Run Asset related functional tests for the API', function() {
                 .put(`/assetmanager/workspaces/${workspace.get_encoded_file_uri()}${test_level_asset.meta.ref}`)
                 .send(asset)
                 .set("Content-Type", "application/json")
-                .set("Accept", 'application/json')
+                .set("accept", 'application/json')
                 .set("Last-Modified", workspace.get_last_modified(test_level_asset.meta.ref))
                 .expect(200)
                 .end((err, res) => {

--- a/test/performance/big_asset.js
+++ b/test/performance/big_asset.js
@@ -70,7 +70,7 @@ describe('Run Asset related functional tests for the API', function () {
             client
                 .put(`/assetmanager/workspaces/${workspace.get_encoded_file_uri()}${asset_ref}`)
                 .send(asset)
-                .set("Content-Type", "application/vnd.bilrost.level+json")
+                .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect(201)
                 .end((err, res) => {

--- a/test/util/server.js
+++ b/test/util/server.js
@@ -40,6 +40,8 @@ module.exports = fixture => {
             });
             server.use(restify.queryParser());
             server.use(restify.bodyParser());
+            server.use(restify.dateParser());
+
             const client = supertest(server);
 
             // Context


### PR DESCRIPTION
Don't parse JSON argument in REST operations and make sure valid content type are used in integration tests.