### PR TITLE
 Change favorite routes and added favorite list reset integration test

### DIFF
--- a/controllers/favorite.js
+++ b/controllers/favorite.js
@@ -8,24 +8,11 @@ const Handler = require('../lib/handler');
 
 const _workspace_metadata_presenter = require('../assetmanager/workspace_presenter').Workspace_metadata_presenter;
 
-const favorites_regexp = /^\/assetmanager\/workspaces\/([^/]*)\/favorites$/;
-
 module.exports = function(server, context) {
     const favorite = context.favorite;
     const _workspace = require('../assetmanager/workspace')(context);
 
-    server.del(favorites_regexp, async (req, res, next) => {
-        const workspace_identifier = decodeURIComponent(req.params[0]);
-        const handler = new Handler(req, res, next);
-        try {
-            await favorite.remove(workspace_identifier);
-            handler.sendJSON('Ok', 200);
-        } catch (workspace) {
-            handler.handleError(workspace.error || workspace);
-        }
-    });
-
-    server.post('/assetmanager/workspaces/favorites', async (req, res, next) => {
+    server.post('/assetmanager/favorites', async (req, res, next) => {
         const handler = new Handler(req, res, next);
         const workspace_file_uri = req.body.file_uri;
         const workspace_name = req.body.name;
@@ -39,7 +26,18 @@ module.exports = function(server, context) {
         }
     });
 
-    server.post('/assetmanager/workspaces/favorites/reset', async (req, res, next) => {
+    server.del('/assetmanager/favorites/:identifier', async (req, res, next) => {
+        const workspace_identifier = req.params.identifier;
+        const handler = new Handler(req, res, next);
+        try {
+            await favorite.remove(workspace_identifier);
+            handler.sendJSON('Ok', 200);
+        } catch (workspace) {
+            handler.handleError(workspace.error || workspace);
+        }
+    });
+
+    server.post('/assetmanager/favorites/reset', async (req, res, next) => {
         const handler = new Handler(req, res, next);
         try {
             await favorite.flush();

--- a/test/integration/browse.js
+++ b/test/integration/browse.js
@@ -159,7 +159,7 @@ describe('Run Content Browser related test for content browser api', function ()
 
         before("Add bob workspace", function(done) {
 
-            client.post('/assetmanager/workspaces/favorites')
+            client.post('/assetmanager/favorites')
                 .send({ file_uri: workspaces.bob.get_file_uri(), name: workspaces.bob.get_name() })
                 .set("Content-Type", 'application/json')
                 .set("Accept", 'application/json')

--- a/test/integration/workspace.js
+++ b/test/integration/workspace.js
@@ -58,7 +58,7 @@ describe('Run Workspace related functional tests for the API', function() {
         it('Add "example1" Workspace to favorites', function (done) {
 
             client
-                .post('/assetmanager/workspaces/favorites')
+                .post('/assetmanager/favorites')
                 .send({ file_uri: workspaces.alice.get_file_uri(), name: workspaces.alice.get_name() })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -76,7 +76,7 @@ describe('Run Workspace related functional tests for the API', function() {
         it('Add "example2" Workspace to favorites', function(done){
 
             client
-                .post('/assetmanager/workspaces/favorites')
+                .post('/assetmanager/favorites')
                 .send({ file_uri: workspaces.bob.get_file_uri(), name: workspaces.bob.get_name() })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -94,7 +94,7 @@ describe('Run Workspace related functional tests for the API', function() {
 
         it("Fail to add an already existing Workspace to favorites", function(done){
             client
-                .post('/assetmanager/workspaces/favorites')
+                .post('/assetmanager/favorites')
                 .send({ file_uri: workspaces.alice.get_file_uri() })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -113,7 +113,7 @@ describe('Run Workspace related functional tests for the API', function() {
         it("Fail to add invalid Workspace to favorites", function(done){
 
             client
-                .post('/assetmanager/workspaces/favorites')
+                .post('/assetmanager/favorites')
                 .send({ file_uri: workspaces.luke.get_file_uri() })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
@@ -133,7 +133,7 @@ describe('Run Workspace related functional tests for the API', function() {
         it('Remove "example1" Workspace from favorites', function(done){
 
             client
-                .delete(`/assetmanager/workspaces/${workspaces.alice.get_name()}/favorites`)
+                .delete(`/assetmanager/favorites/${workspaces.alice.get_name()}`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end(async (err, res) => {
@@ -146,9 +146,9 @@ describe('Run Workspace related functional tests for the API', function() {
 
         });
 
-        it('Remove "example2" Workspace from favorites', function(done){
+        it('Remove all favorite workspaces', function(done){
             client
-                .delete(`/assetmanager/workspaces/${workspaces.bob.get_name()}/favorites`)
+                .post(`/assetmanager/favorites/reset`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end(async (err, res) => {
@@ -163,7 +163,7 @@ describe('Run Workspace related functional tests for the API', function() {
 
         it('Check workspace removal is idempotent', function(done){
             client
-                .delete(`/assetmanager/workspaces/${workspaces.bob.get_name()}/favorites`)
+                .delete(`/assetmanager/favorites/${workspaces.bob.get_name()}`)
                 .set("Accept", 'application/json')
                 .expect(200)
                 .end((err, res) => {
@@ -243,7 +243,7 @@ describe('Run Workspace related functional tests for the API', function() {
 
         it('Forget the copied Workspace from favorite list', function(done){
             client
-                .delete(`/assetmanager/workspaces/${workspaces.carol.get_encoded_file_uri()}/favorites`)
+                .delete(`/assetmanager/favorites/${workspaces.carol.get_encoded_file_uri()}`)
                 .send()
                 .set("Accept", 'application/json')
                 .set("Content-Type", "application/json")


### PR DESCRIPTION
`/assetmanager/workspaces/:identifier` workspace route was colliding with `/assetmanager/workspaces/favorites` favorite one.

This PR renames favorite routes to:
- `GET /assetmanager/favorites`
- `POST /assetmanager/favorites`
- `DEL /assetmanager/favorites/:name`