### PR TITLE
Fix url in responses

### DIFF
--- a/assetmanager/subscription_manager.js
+++ b/assetmanager/subscription_manager.js
@@ -29,7 +29,7 @@ class Subscription_manager {
     }
 
     get_subscriptions () {
-        let subscriptions = this.subscriptions.map(subscription => Subscription_presenter.present(subscription, this.workspace.properties));
+        let subscriptions = this.subscriptions.map(subscription => Subscription_presenter.present(subscription, this.workspace.get_encoded_file_uri()));
         return subscriptions;
     }
 
@@ -74,7 +74,7 @@ class Subscription_manager {
                         .then(() => subscription.pull_dependencies())
                         .then(() => subscription.validate_dependencies())
                         .then(() => this.subscriptions.push(subscription))
-                        .then(() => Subscription_presenter.present(subscription, this.workspace.properties))
+                        .then(() => Subscription_presenter.present(subscription, this.workspace.get_encoded_file_uri()))
                         .catch(err => {
                             throw _error_outputs.INTERNALERROR(err);
                         });

--- a/assetmanager/subscription_presenter.js
+++ b/assetmanager/subscription_presenter.js
@@ -6,10 +6,10 @@
 
 module.exports = {
     Subscription_metadata_presenter: {
-        present: (subscription, workspace) => {
+        present: (subscription, encoded_file_uri) => {
             return {
                 id: subscription.id,
-                url: `/assetmanager/workspaces/${workspace.name}/subscriptions/${subscription.id}`,
+                url: `/assetmanager/workspaces/${encoded_file_uri}/subscriptions/${subscription.id}`,
                 type: subscription.type,
                 descriptor: subscription.descriptor,
             };

--- a/assetmanager/workspace.js
+++ b/assetmanager/workspace.js
@@ -55,6 +55,7 @@ const Workspace = function(file_uri, context) {
     }
 
     this.get_file_uri = () => file_uri;
+    this.get_encoded_file_uri = () => encodeURIComponent(file_uri);
     this.get_base_absolute_path = () => utilities.convert_file_uri_to_path(this.get_file_uri());
     this.get_name = () => this.properties.name;
     this.get_guid = () => this.properties.guid;
@@ -133,8 +134,8 @@ const Workspace = function(file_uri, context) {
             }
 
             // add other metadata to the resource
-            this.properties.resources_url = `/contentbrowser/workspaces/${this.get_name()}/resources/`;
-            this.properties.assets_url = `/contentbrowser/workspaces/${this.get_name()}/assets/`;
+            this.properties.resources_url = `/contentbrowser/workspaces/${this.get_encoded_file_uri()}/resources/`;
+            this.properties.assets_url = `/contentbrowser/workspaces/${this.get_encoded_file_uri()}/assets/`;
         }, err => {
             this.error = _error_outputs.NOTFOUND(err);
             throw this;

--- a/controllers/asset.js
+++ b/controllers/asset.js
@@ -56,7 +56,7 @@ module.exports = function(server, context) {
                         let output = asset.output;
                         if (output.items) {
                             output.items = output.items.map(ass => {
-                                ass.url = _path.join("/contentbrowser/workspaces/", workspace.get_guid(), ass.meta.ref);
+                                ass.url = _path.join("/contentbrowser/workspaces/", workspace.get_encoded_file_uri(), ass.meta.ref);
                                 return ass;
                             });
                         }

--- a/test/util/mocks/workspace.js
+++ b/test/util/mocks/workspace.js
@@ -19,6 +19,7 @@ module.exports = (guid, worskpace_path, host_vcs, ifs_map, branch, adapter) => {
     this.utilities = workspace_utilities(this.get_internal_file_path);
     this.adapter = adapter ? adapter : mock_ifs_adapter(worskpace_path, ifs_map);
     this.get_adapter = () => this.adapter;
+    this.get_encoded_file_uri = () => worskpace_path;
     this.project = {
         get_host_vcs: () => host_vcs
     };


### PR DESCRIPTION
Some responses sometimes include urls that were wrongs after deprecating workspace guid. This PR fix these output data.