### PR TITLE
Clean assetmanager api outputs

### DIFF
--- a/assetmanager/asset.js
+++ b/assetmanager/asset.js
@@ -197,10 +197,7 @@ asset_model = workspace => {
                         // insert final slash to tell to unformat well final file name because this is a directory name
                         directory_path = `${directory_path}/`;
                         const ref = `${workspace_utilities.relative_path_to_ref(directory_path)}/`;
-                        return {
-                            url: `/contentbrowser/workspaces/${workspace.get_file_uri()}${ref}`,
-                            ref
-                        };
+                        return ref;
                     });
                     search_results.totalItems = search_results.items.length;
                     return search_results;

--- a/assetmanager/subscription_presenter.js
+++ b/assetmanager/subscription_presenter.js
@@ -6,10 +6,9 @@
 
 module.exports = {
     Subscription_metadata_presenter: {
-        present: (subscription, workspace) => {
+        present: subscription => {
             return {
                 id: subscription.id,
-                url: `/assetmanager/workspaces/${workspace.name}/subscriptions/${subscription.id}`,
                 type: subscription.type,
                 descriptor: subscription.descriptor,
             };

--- a/assetmanager/workspace.js
+++ b/assetmanager/workspace.js
@@ -131,10 +131,6 @@ const Workspace = function(file_uri, context) {
             if (!this.properties.stage) {
                 this.properties.stage = [];
             }
-
-            // add other metadata to the resource
-            this.properties.resources_url = `/contentbrowser/workspaces/${this.get_name()}/resources/`;
-            this.properties.assets_url = `/contentbrowser/workspaces/${this.get_name()}/assets/`;
         }, err => {
             this.error = _error_outputs.NOTFOUND(err);
             throw this;

--- a/assetmanager/workspace_presenter.js
+++ b/assetmanager/workspace_presenter.js
@@ -7,19 +7,16 @@
 module.exports = {
     Workspace_metadata_presenter: {
         present: ({ properties }) => ({
-            name: properties.name,
             description: properties.description,
-            type: properties.type
         })
     },
     Workspace_presenter: {
-        present: ({ properties, project }) => ({
+        present: ({ properties, project, get_file_uri }) => ({
             project: {
                 full_name: project.get_full_name(),
                 host: project.get_host_vcs()
             },
-            guid: properties.guid,
-            name: properties.name,
+            file_uri: get_file_uri(),
             description: properties.description,
             version: properties.version,
             pushed_at: properties.pushed_at,

--- a/controllers/asset.js
+++ b/controllers/asset.js
@@ -107,28 +107,22 @@ module.exports = function(server, context) {
         const workspace_identifier = sanitize(req.params[0]);
         const asset_ref = sanitize(req.params[1]);
         const modified = sanitize(req.headers['last-modified']);
-        const is_body_a_json_to_parse = typeof req.body === 'string' || req.body instanceof Buffer;
-        let asset_representation;
-        try {
-            asset_representation = is_body_a_json_to_parse ? JSON.parse(req.body) : req.body;
-        } catch (err) {
-            return handler.handleError(errors.CORRUPT(err));
-        }
+        const asset_representation = req.body;
         const workspace = await _workspace.find(workspace_identifier);
         try {
             await workspace.check_overall_validation();
             const asset = await workspace.asset.create(asset_ref, asset_representation);
-            return handler.sendJSON(asset, 201);
+            handler.sendJSON(asset, 201);
         } catch (error) {
             if (error && error.statusCode === 403) {
                 try {
                     const asset = await workspace.asset.replace(asset_ref, asset_representation, modified);
-                    return handler.sendJSON(asset, 200);
+                    handler.sendJSON(asset, 200);
                 } catch (error) {
-                    return handler.handleError(error);
+                    handler.handleError(error);
                 }
             } else {
-                return handler.handleError(error);
+                handler.handleError(error);
             }
         }
     });
@@ -138,12 +132,7 @@ module.exports = function(server, context) {
         const workspace_identifier = sanitize(req.params[0]);
         const asset_ref = sanitize(req.params[1]);
         const modified = sanitize(req.headers['last-modified']);
-        var new_asset_ref;
-        try {
-            new_asset_ref = JSON.parse(req.body).new;
-        } catch (err) {
-            return handler.handleError(errors.CORRUPT(err));
-        }
+        const new_asset_ref = req.body.new;
         let workspace;
         try {
             workspace = await _workspace.find(workspace_identifier);

--- a/controllers/asset.js
+++ b/controllers/asset.js
@@ -54,12 +54,6 @@ module.exports = function(server, context) {
                 return Asset.find_asset_by_ref(workspace, asset_ref, options)
                     .then(asset => {
                         let output = asset.output;
-                        if (output.items) {
-                            output.items = output.items.map(ass => {
-                                ass.url = _path.join("/contentbrowser/workspaces/", workspace.get_guid(), ass.meta.ref);
-                                return ass;
-                            });
-                        }
                         if (asset.indexOfMoreResults) {
                             output.nextLink = get_next_url(req.url, asset.indexOfMoreResults);
                         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ module.exports = function(options) {
     server.server.setTimeout(60000 * 60 * 10);
 
     server.use(restify.queryParser()); // split arguments in req.query
+    server.use(restify.bodyParser()); // POST,PUT mapped in req.body
     server.use(restify.dateParser()); // parse dates into javascript date format
     restify.defaultResponseHeaders = false;
 
@@ -43,8 +44,6 @@ module.exports = function(options) {
     restify.CORS.ALLOW_HEADERS.push('x-session-id');
 
     server.use(restify.CORS());
-
-    server.use(restify.bodyParser()); // POST mapped in req.params, req.body
 
     function unknownMethodHandler(req, res) {
         // eslint-disable-next-line no-console

--- a/test/end-to-end/cli/use_case_1.js
+++ b/test/end-to-end/cli/use_case_1.js
@@ -80,7 +80,7 @@ describe('Integration tests --DO_NOT_RUN', function() {
             should.not.exist(error);
             // eslint-disable-next-line no-console
             console.log(stderr);
-            should.equal(stdout.match(/success/gi).length, 14);
+            should.equal(stdout.match(/success/gi).length, 15);
             git.read('/resources/alice_resource.txt', { rev: 'HEAD' })
                 .then(() => done('Alice resource still exist!'))
                 .catch(err => {

--- a/test/end-to-end/db.js
+++ b/test/end-to-end/db.js
@@ -33,7 +33,6 @@ describe('Check database behaviors', function() {
                 });
                 client
                     .get(`/contentbrowser/workspaces/${workspace.get_encoded_file_uri()}/assets/`)
-                    .set("Content-Type", "application/json")
                     .set("Accept", 'application/json')
                     .expect("Content-Type", "application/json")
                     .expect(200)
@@ -64,7 +63,6 @@ describe('Check database behaviors', function() {
         it('List persisted asset', function (done) {
             client
                 .get(`/contentbrowser/workspaces/${workspace.get_encoded_file_uri()}/assets/`)
-                .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect("Content-Type", "application/json")
                 .expect(200)

--- a/test/integration/asset.js
+++ b/test/integration/asset.js
@@ -377,7 +377,7 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(`/assetmanager/workspaces/${workspace.get_encoded_file_uri()}/rename${test_level_asset.meta.ref}`)
                 .send({ new: new_asset_ref })
-                .set("Content-Type", "application/vnd.bilrost.asset+json")
+                .set("Content-Type", "application/json")
                 .set("Accept", "application/json")
                 .set("Last-Modified", workspace.read_asset(asset_ref).meta.modified)
                 .expect(200)
@@ -414,8 +414,8 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(path.join('/assetmanager/workspaces/', workspace.get_encoded_file_uri(), 'rename', '/assets/unvalid'))
                 .send({ new: new_asset_ref})
-                .set("Content-Type", "application/vnd.bilrost.asset+json")
-                .set("Accept", 'application/json')
+                .set("Content-Type", "application/json")
+                .set("Accept", "application/json")
                 .set("Last-Modified", workspace.format_asset().meta.modified)
                 .expect(404)
                 .end((err, res) => {
@@ -432,7 +432,7 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(path.join('/assetmanager/workspaces/', workspace.get_encoded_file_uri(), 'rename', new_asset_ref))
                 .send({ new: new_asset_ref})
-                .set("Content-Type", "application/vnd.bilrost.asset+json")
+                .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .set("Last-Modified", "2016-03-18T10:54:05.860Z")
                 .expect(412)
@@ -452,7 +452,7 @@ describe('Run Asset related functional tests for the API', function() {
                 .send({ new: '/invalid' })
                 .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
-                .set("Last-Modified", workspace.format_asset().meta.modified)
+                .set("Last-Modified", workspace.read_asset(test_003.meta.ref).meta.modified)
                 .expect(400)
                 .end((err, res) => {
                     if (err) {
@@ -468,10 +468,10 @@ describe('Run Asset related functional tests for the API', function() {
             client
                 .post(path.join('/assetmanager/workspaces/', workspace.get_encoded_file_uri(), 'rename', test_003.meta.ref))
                 .send({ new: '/invalid' })
-                .set("Content-Type", "application/json")
+                .set("Content-Type", "application/invalid/json")
                 .set("Accept", 'application/json')
-                .set("Last-Modified", workspace.format_asset().meta.modified)
-                .expect(400)
+                .set("Last-Modified", workspace.read_asset(test_003.meta.ref).meta.modified)
+                .expect(500)
                 .end((err, res) => {
                     if (err) {
                         return done({ error: err.toString(), status: res.status, body: res.body });
@@ -499,7 +499,7 @@ describe('Run Asset related functional tests for the API', function() {
                 .put(`/assetmanager/workspaces/${workspace.get_encoded_file_uri()}${test_level_asset.meta.ref}`)
                 .send(asset)
                 .set("Content-Type", "application/json")
-                .set("Accept", 'application/json')
+                .set("accept", 'application/json')
                 .set("Last-Modified", workspace.get_last_modified(test_level_asset.meta.ref))
                 .expect(200)
                 .end((err, res) => {

--- a/test/integration/browse.js
+++ b/test/integration/browse.js
@@ -238,7 +238,7 @@ describe('Run Content Browser related test for content browser api', function ()
                     }
                     obj.items.length.should.be.equal(1);
                     obj.totalItems.should.be.equal(1);
-                    obj.items[0].name.should.be.equal(workspaces.luke.get_name());
+                    obj.items[0].file_uri.should.be.equal(workspaces.luke.get_file_uri());
                     done();
                 });
 
@@ -426,45 +426,6 @@ describe('Run Content Browser related test for content browser api', function ()
                 });
         });
 
-    });
-
-    describe('-- [GET] /contentbrowser/workspaces/{id}', function() {
-
-        it('retrieves eloise by name', (done) => {
-            client
-                .get(`/contentbrowser/workspaces/${workspaces.bob.get_encoded_file_uri()}`)
-                .set("Content-Type", "application/json")
-                .set("Accept", 'application/json')
-                .expect("Content-Type", "application/json")
-                .expect(200)
-                .end((err, res) => {
-                    const obj = res.body;
-                    if (err) {
-                        return done({ error: err.toString(), status: res.status, body: obj });
-                    }
-                    obj.items.should.have.lengthOf(1);
-                    obj.items.should.containDeep([workspaces.bob.get_workspace_resource()]);
-                    done();
-                });
-        });
-
-        it('retrieves eloise by file uri', (done) => {
-            client
-                .get(`/contentbrowser/workspaces/${workspaces.bob.get_encoded_file_uri()}`)
-                .set("Content-Type", "application/json")
-                .set("Accept", 'application/json')
-                .expect("Content-Type", "application/json")
-                .expect(200)
-                .end((err, res) => {
-                    const obj = res.body;
-                    if (err) {
-                        return done({ error: err.toString(), status: res.status, body: obj });
-                    }
-                    obj.items.should.have.lengthOf(1);
-                    obj.items.should.containDeep([workspaces.bob.get_workspace_resource()]);
-                    done();
-                });
-        });
     });
 
     describe('-- [GET] /contentbrowser/workspaces/{workspace_name}/assets/', function() {

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -36,7 +36,7 @@ describe('Authentication', function() {
     before('create server', function(done) {
         server = restify.createServer({});
         server.use(restify.queryParser());
-        server.use(restify.bodyParser()); // POST mapped in req.params, req.body
+        server.use(restify.bodyParser());
         config(server, mock_config);
         server.listen(PORT, done);
         server.server.setTimeout(10);

--- a/test/performance/big_asset.js
+++ b/test/performance/big_asset.js
@@ -70,7 +70,7 @@ describe('Run Asset related functional tests for the API', function () {
             client
                 .put(`/assetmanager/workspaces/${workspace.get_encoded_file_uri()}${asset_ref}`)
                 .send(asset)
-                .set("Content-Type", "application/vnd.bilrost.level+json")
+                .set("Content-Type", "application/json")
                 .set("Accept", 'application/json')
                 .expect(201)
                 .end((err, res) => {

--- a/test/unit/lib/authentication.js
+++ b/test/unit/lib/authentication.js
@@ -18,7 +18,7 @@ describe('Authentication', function() {
     before('create server', function(done) {
         server = restify.createServer({});
         server.use(restify.queryParser());
-        server.use(restify.bodyParser()); // POST mapped in req.params, req.body
+        server.use(restify.bodyParser());
         authentication(server, backend);
         server.listen(PORT, done);
         server.server.setTimeout(10);

--- a/test/util/server.js
+++ b/test/util/server.js
@@ -40,6 +40,8 @@ module.exports = fixture => {
             });
             server.use(restify.queryParser());
             server.use(restify.bodyParser());
+            server.use(restify.dateParser());
+
             const client = supertest(server);
 
             // Context


### PR DESCRIPTION
- Don't answer with workspace guid
- Answer with workspace file_uri
- Remove forward uri in answers when not needed; only next page urls are kept